### PR TITLE
Send Kalshi market/series settlement rules into Grok prompt (Fixes #3)

### DIFF
--- a/Untitled
+++ b/Untitled
@@ -1,1 +1,0 @@
-kalshi-genai-trading-bot

--- a/Untitled
+++ b/Untitled
@@ -1,0 +1,1 @@
+kalshi-genai-trading-bot

--- a/new_position_bot/grok_client.py
+++ b/new_position_bot/grok_client.py
@@ -12,10 +12,16 @@ class GrokClient:
         self.model = model
         self.base_url = "https://api.x.ai/v1/chat/completions"
 
-    def analyze_market(self, market_data: dict) -> dict:
+    def analyze_market(self, market_data: dict, settlement_rules: str = "") -> dict:
         """
         Sends market data to Grok and asks for a trading decision.
         Returns the JSON parsed response.
+
+        Args:
+            market_data: Market dict from Kalshi list endpoint.
+            settlement_rules: Pre-formatted settlement rules text to inject
+                              into the prompt so Grok understands how the
+                              market resolves.
         """
 
         system_prompt = (
@@ -23,6 +29,8 @@ class GrokClient:
             "You analyze market metadata to find high-probability opportunities. "
             "You may recommend buying either the 'yes' side OR the 'no' side, "
             "or choose to pass if there isn't a good trade. "
+            "When settlement rules are provided, treat them as the authoritative "
+            "definition of how the market resolves. "
             "Respond ONLY with a valid RFC 8259 JSON object containing exactly three keys: "
             "'ticker' (string or null), 'side' (\"yes\", \"no\", or null), and "
             "'explanation' (string or null)."
@@ -36,6 +44,12 @@ class GrokClient:
             f"Subtitle: {market_data.get('subtitle')}\n"
             f"Category: {market_data.get('category')}\n"
             f"Current Yes Price: {market_data.get('yes_ask', 'N/A')}\n\n"
+        )
+
+        if settlement_rules:
+            user_content += f"{settlement_rules}\n\n"
+
+        user_content += (
             "If you recommend a trade, return the ticker and which side to buy "
             "('yes' or 'no'), with a short explanation. "
             "If you do NOT recommend a trade, return null for ticker and side, "

--- a/new_position_bot/kalshi_client.py
+++ b/new_position_bot/kalshi_client.py
@@ -169,6 +169,16 @@ class KalshiClient:
         
         return all_orders
 
+    def get_market(self, ticker: str) -> Dict:
+        """Fetches detailed data for a single market, including settlement rules."""
+        data = self._request("GET", f"/markets/{ticker}")
+        return data.get("market", {})
+
+    def get_series(self, series_ticker: str) -> Dict:
+        """Fetches series metadata including settlement sources and contract URLs."""
+        data = self._request("GET", f"/series/{series_ticker}")
+        return data.get("series", {})
+
     def create_market_order(
         self,
         ticker: str,

--- a/new_position_bot/main.py
+++ b/new_position_bot/main.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict
 
 import functions_framework
 from dotenv import load_dotenv
@@ -11,6 +12,102 @@ from utils import get_env_var, get_private_key
 # Configure basic logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def _derive_series_ticker(event_ticker: str) -> str:
+    """Best-effort extraction of series ticker from an event ticker.
+
+    Kalshi convention is typically ``SERIES-DATE…`` so we strip the
+    trailing date segment(s).  Returns the event ticker unchanged if
+    we can't identify a date-like suffix.
+    """
+    parts = event_ticker.split("-")
+    if len(parts) <= 1:
+        return event_ticker
+
+    # Walk from the right and drop parts that look like dates (digits,
+    # short alphanumeric date codes like "26APR02", qualifier prefixes
+    # like "T95000").
+    prefix_parts = []
+    for part in parts:
+        has_digit = any(c.isdigit() for c in part)
+        if has_digit and prefix_parts:
+            break
+        prefix_parts.append(part)
+
+    return "-".join(prefix_parts) if prefix_parts else event_ticker
+
+
+def build_settlement_rules(
+    kalshi: KalshiClient,
+    ticker: str,
+    series_cache: Dict[str, Dict],
+) -> str:
+    """Fetch market detail + series and return a formatted rules block.
+
+    Series lookups are cached in *series_cache* (keyed by series ticker)
+    to avoid redundant API calls within a single bot run.
+    """
+    lines = ["--- Settlement Rules (authoritative for resolution) ---"]
+
+    try:
+        detail = kalshi.get_market(ticker)
+    except Exception as exc:
+        logger.warning("Could not fetch market detail for %s: %s", ticker, exc)
+        return ""
+
+    yes_sub = detail.get("yes_sub_title", "")
+    no_sub = detail.get("no_sub_title", "")
+    rules_primary = detail.get("rules_primary", "")
+    rules_secondary = detail.get("rules_secondary", "")
+
+    if yes_sub:
+        lines.append(f"Yes outcome: {yes_sub}")
+    if no_sub:
+        lines.append(f"No outcome: {no_sub}")
+    if rules_primary:
+        lines.append(f"Primary rules: {rules_primary}")
+    if rules_secondary:
+        lines.append(f"Secondary rules: {rules_secondary}")
+
+    # Attempt to enrich with series-level settlement sources
+    event_ticker = detail.get("event_ticker", "")
+    if event_ticker:
+        series_ticker = _derive_series_ticker(event_ticker)
+        series = series_cache.get(series_ticker)
+        if series is None:
+            try:
+                series = kalshi.get_series(series_ticker)
+                series_cache[series_ticker] = series
+            except Exception as exc:
+                logger.debug(
+                    "Series lookup failed for %s (derived from %s): %s",
+                    series_ticker,
+                    event_ticker,
+                    exc,
+                )
+                series = {}
+                series_cache[series_ticker] = series
+
+        sources = series.get("settlement_sources", [])
+        if sources:
+            source_strs = []
+            for src in sources:
+                name = src.get("name", "")
+                url = src.get("url", "")
+                source_strs.append(f"{name} ({url})" if url else name)
+            lines.append(f"Settlement sources: {'; '.join(source_strs)}")
+
+        frequency = series.get("frequency", "")
+        if frequency:
+            lines.append(f"Settlement frequency: {frequency}")
+
+        contract_url = series.get("contract_url", "")
+        if contract_url:
+            lines.append(f"Contract filing: {contract_url}")
+
+    lines.append("--- End Settlement Rules ---")
+    return "\n".join(lines)
 
 
 def run_bot_logic():
@@ -77,6 +174,8 @@ def run_bot_logic():
             lookback_hours,
         )
 
+        series_cache: Dict[str, Dict] = {}
+
         for market in viable_new_markets:
             ticker = market["ticker"]
 
@@ -92,8 +191,12 @@ def run_bot_logic():
                 market.get("no_ask"),
             )
 
-            # 4. Consult Grok
-            recommendation = grok.analyze_market(market)
+            # 4. Fetch settlement rules and consult Grok
+            settlement_rules = build_settlement_rules(kalshi, ticker, series_cache)
+            if settlement_rules:
+                logger.info("Injected settlement rules for %s", ticker)
+
+            recommendation = grok.analyze_market(market, settlement_rules=settlement_rules)
 
             rec_ticker = recommendation.get("ticker")
             explanation = recommendation.get("explanation")

--- a/new_position_bot/tests/test_grok_client.py
+++ b/new_position_bot/tests/test_grok_client.py
@@ -1,5 +1,4 @@
-import json
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from grok_client import GrokClient
 

--- a/new_position_bot/tests/test_grok_client.py
+++ b/new_position_bot/tests/test_grok_client.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, call, patch
 
 from grok_client import GrokClient
 
@@ -42,3 +43,66 @@ def test_analyze_market_null():
 
         result = client.analyze_market({"ticker": "ABC"})
         assert result["ticker"] is None
+
+
+def test_analyze_market_includes_settlement_rules_in_prompt():
+    """When settlement_rules are provided the user prompt must contain them."""
+    client = GrokClient("api_key")
+    rules_text = (
+        "--- Settlement Rules (authoritative for resolution) ---\n"
+        "Yes outcome: Above 3.5%\n"
+        "Primary rules: Resolves Yes if CPI-U > 3.5%.\n"
+        "--- End Settlement Rules ---"
+    )
+
+    mock_response = {
+        "choices": [
+            {
+                "message": {
+                    "content": '{"ticker": "CPI-25APR-T3.5", "side": "yes", '
+                    '"explanation": "CPI expected above 3.5%"}'
+                }
+            }
+        ]
+    }
+
+    with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = mock_response
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        client.analyze_market(
+            {"ticker": "CPI-25APR-T3.5", "title": "CPI Above 3.5%"},
+            settlement_rules=rules_text,
+        )
+
+        sent_payload = mock_post.call_args[1]["json"]
+        user_message = sent_payload["messages"][1]["content"]
+        assert "Settlement Rules" in user_message
+        assert "Resolves Yes if CPI-U > 3.5%" in user_message
+        assert "Above 3.5%" in user_message
+
+
+def test_analyze_market_no_rules_still_works():
+    """Passing empty settlement_rules should not add the rules block."""
+    client = GrokClient("api_key")
+    mock_response = {
+        "choices": [
+            {
+                "message": {
+                    "content": '{"ticker": null, "side": null, "explanation": "skip"}'
+                }
+            }
+        ]
+    }
+
+    with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = mock_response
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        client.analyze_market({"ticker": "ABC"}, settlement_rules="")
+
+        sent_payload = mock_post.call_args[1]["json"]
+        user_message = sent_payload["messages"][1]["content"]
+        assert "Settlement Rules" not in user_message

--- a/new_position_bot/tests/test_kalshi_client.py
+++ b/new_position_bot/tests/test_kalshi_client.py
@@ -170,3 +170,51 @@ def test_get_orders_returns_all_orders_when_no_identifier(mock_kalshi):
         orders = mock_kalshi.get_orders(bot_identifier=None)
 
         assert len(orders) == 2
+
+
+def test_get_market_returns_market_detail(mock_kalshi):
+    with patch.object(mock_kalshi, "_request") as mock_req:
+        mock_req.return_value = {
+            "market": {
+                "ticker": "CPI-25APR-T3.5",
+                "event_ticker": "CPI-25APR",
+                "yes_sub_title": "Above 3.5%",
+                "no_sub_title": "3.5% or below",
+                "rules_primary": "Resolves Yes if CPI-U > 3.5%.",
+                "rules_secondary": "Based on seasonally adjusted data.",
+            }
+        }
+
+        market = mock_kalshi.get_market("CPI-25APR-T3.5")
+
+        mock_req.assert_called_once_with("GET", "/markets/CPI-25APR-T3.5")
+        assert market["ticker"] == "CPI-25APR-T3.5"
+        assert market["rules_primary"] == "Resolves Yes if CPI-U > 3.5%."
+        assert market["yes_sub_title"] == "Above 3.5%"
+
+
+def test_get_series_returns_settlement_sources(mock_kalshi):
+    with patch.object(mock_kalshi, "_request") as mock_req:
+        mock_req.return_value = {
+            "series": {
+                "ticker": "CPI",
+                "frequency": "monthly",
+                "title": "Consumer Price Index",
+                "settlement_sources": [
+                    {
+                        "name": "Bureau of Labor Statistics",
+                        "url": "https://www.bls.gov/cpi/",
+                    }
+                ],
+                "contract_url": "https://kalshi.com/contracts/cpi",
+                "contract_terms_url": "https://kalshi.com/terms/cpi",
+            }
+        }
+
+        series = mock_kalshi.get_series("CPI")
+
+        mock_req.assert_called_once_with("GET", "/series/CPI")
+        assert series["ticker"] == "CPI"
+        assert series["frequency"] == "monthly"
+        assert len(series["settlement_sources"]) == 1
+        assert series["settlement_sources"][0]["name"] == "Bureau of Labor Statistics"

--- a/new_position_bot/tests/test_settlement_rules.py
+++ b/new_position_bot/tests/test_settlement_rules.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/new_position_bot/tests/test_settlement_rules.py
+++ b/new_position_bot/tests/test_settlement_rules.py
@@ -1,0 +1,105 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from main import _derive_series_ticker, build_settlement_rules
+
+
+class TestDeriveSeriesTicker:
+    def test_simple_series_date(self):
+        assert _derive_series_ticker("CPI-25APR") == "CPI"
+
+    def test_series_with_multi_segment_date(self):
+        assert _derive_series_ticker("KXBTC-26APR02") == "KXBTC"
+
+    def test_no_date_suffix(self):
+        assert _derive_series_ticker("ONLYSERIES") == "ONLYSERIES"
+
+    def test_alphanumeric_series_prefix(self):
+        assert _derive_series_ticker("INX500-26APR02") == "INX500"
+
+    def test_single_part(self):
+        assert _derive_series_ticker("SOLO") == "SOLO"
+
+
+class TestBuildSettlementRules:
+    @pytest.fixture
+    def mock_kalshi(self):
+        client = MagicMock()
+        return client
+
+    def test_builds_full_rules_block(self, mock_kalshi):
+        mock_kalshi.get_market.return_value = {
+            "ticker": "CPI-25APR-T3.5",
+            "event_ticker": "CPI-25APR",
+            "yes_sub_title": "Above 3.5%",
+            "no_sub_title": "3.5% or below",
+            "rules_primary": "Resolves Yes if CPI-U exceeds 3.5%.",
+            "rules_secondary": "Based on seasonally adjusted data.",
+        }
+        mock_kalshi.get_series.return_value = {
+            "ticker": "CPI",
+            "frequency": "monthly",
+            "settlement_sources": [
+                {"name": "Bureau of Labor Statistics", "url": "https://bls.gov/cpi/"}
+            ],
+            "contract_url": "https://kalshi.com/contracts/cpi",
+        }
+
+        cache = {}
+        result = build_settlement_rules(mock_kalshi, "CPI-25APR-T3.5", cache)
+
+        assert "Above 3.5%" in result
+        assert "3.5% or below" in result
+        assert "Resolves Yes if CPI-U exceeds 3.5%" in result
+        assert "seasonally adjusted" in result
+        assert "Bureau of Labor Statistics" in result
+        assert "monthly" in result
+        assert "https://kalshi.com/contracts/cpi" in result
+        assert "CPI" in cache
+
+    def test_caches_series_across_calls(self, mock_kalshi):
+        mock_kalshi.get_market.return_value = {
+            "ticker": "CPI-25APR-T3.5",
+            "event_ticker": "CPI-25APR",
+            "yes_sub_title": "Above 3.5%",
+            "no_sub_title": "3.5% or below",
+            "rules_primary": "Resolves Yes.",
+            "rules_secondary": "",
+        }
+
+        cache = {
+            "CPI": {
+                "settlement_sources": [{"name": "BLS", "url": ""}],
+                "frequency": "monthly",
+            }
+        }
+
+        build_settlement_rules(mock_kalshi, "CPI-25APR-T3.5", cache)
+
+        mock_kalshi.get_series.assert_not_called()
+
+    def test_returns_empty_when_get_market_fails(self, mock_kalshi):
+        mock_kalshi.get_market.side_effect = Exception("API error")
+
+        result = build_settlement_rules(mock_kalshi, "BAD-TICKER", {})
+
+        assert result == ""
+
+    def test_graceful_when_series_fails(self, mock_kalshi):
+        mock_kalshi.get_market.return_value = {
+            "ticker": "NEW-26APR",
+            "event_ticker": "NEW-26APR",
+            "yes_sub_title": "Yes",
+            "no_sub_title": "No",
+            "rules_primary": "Some rule.",
+            "rules_secondary": "",
+        }
+        mock_kalshi.get_series.side_effect = Exception("Series not found")
+
+        cache = {}
+        result = build_settlement_rules(mock_kalshi, "NEW-26APR", cache)
+
+        assert "Some rule." in result
+        assert "Settlement sources" not in result
+        assert "NEW" in cache


### PR DESCRIPTION

<p>Inject Kalshi market/series settlement rules into Grok prompt (Fixes #&lt;ISSUE_NUMBER&gt;)</p>

<h3>PR Description</h3>

<h4>Summary</h4>
<p>
  This PR makes the bot send <strong>Kalshi market settlement rules</strong> to Grok when deciding whether to trade.
  Since Kalshi doesn’t provide a single “full rulebook text” endpoint, we reconstruct the authoritative resolution criteria using:
</p>
<ul>
  <li><code>GET /markets/{ticker}</code> (market-specific settlement descriptions like <code>rules_primary</code> / <code>rules_secondary</code>, plus yes/no subtitles)</li>
  <li><code>GET /series/{series_ticker}</code> (series-level settlement methodology like <code>settlement_sources</code> and <code>frequency</code>)</li>
</ul>

<h4>What changed</h4>
<ul>
  <li><code>kalshi_client.py</code>: added <code>get_market()</code> and <code>get_series()</code> wrappers.</li>
  <li><code>main.py</code>: builds a structured “Settlement Rules (authoritative for resolution)” block and injects it into the prompt (with series caching).</li>
  <li><code>grok_client.py</code>: <code>analyze_market()</code> now accepts optional <code>settlement_rules</code> and includes it in the user message.</li>
</ul>

<h4>Why</h4>
<p>
  Injecting settlement criteria improves Grok’s ability to reason about <strong>Yes/No resolution definitions</strong>,
  reducing ambiguity when markets are interpreted incorrectly.
</p>

<h4>Test plan</h4>
<p><code>pytest tests/ -v</code></p>
