### PR TITLE
 Fix contract sizing and add live API flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ BY ACCESSING, DOWNLOADING, INSTALLING, OR USING THIS SOFTWARE (THE "SOFTWARE"), 
 4. Ensure you're on Python 3.13.11, and run `pip install -r requirements.txt`.
 5. In the project root, run `python main.py`.
 
+The bot uses the Kalshi demo environment by default. To trade against Kalshi production,
+run `python main.py --live`.
+
 ## New Position Bot design notes
 * Vibe coded: As this bot will use an LLM to make decisions surrounding prediction market trades, it seemed appropriate to also have the LLM write the initial code for the project. The many iterations of prompts used to generate this codebase are found in `/prompts`.
 * Role prompting: The prompt sent to the LLM tells it that it's a professional prediction market trader, in the hopes of enhancing the output quality. 

--- a/new_position_bot/grok_client.py
+++ b/new_position_bot/grok_client.py
@@ -12,7 +12,13 @@ class GrokClient:
         self.model = model
         self.base_url = "https://api.x.ai/v1/chat/completions"
 
-    def analyze_market(self, market_data: dict, settlement_rules: str = "") -> dict:
+    def analyze_market(
+        self,
+        market_data: dict,
+        settlement_rules: str = "",
+        available_funds_cents: int | None = None,
+        spending_limit_remaining_cents: int | None = None,
+    ) -> dict:
         """
         Sends market data to Grok and asks for a trading decision.
         Returns the JSON parsed response.
@@ -22,6 +28,8 @@ class GrokClient:
             settlement_rules: Pre-formatted settlement rules text to inject
                               into the prompt so Grok understands how the
                               market resolves.
+            available_funds_cents: Account balance available for trading.
+            spending_limit_remaining_cents: Remaining configured spending allowance.
         """
 
         system_prompt = (
@@ -31,8 +39,9 @@ class GrokClient:
             "or choose to pass if there isn't a good trade. "
             "When settlement rules are provided, treat them as the authoritative "
             "definition of how the market resolves. "
-            "Respond ONLY with a valid RFC 8259 JSON object containing exactly three keys: "
+            "Respond ONLY with a valid RFC 8259 JSON object containing exactly four keys: "
             "'ticker' (string or null), 'side' (\"yes\", \"no\", or null), and "
+            "'count' (positive integer or null), and "
             "'explanation' (string or null)."
         )
 
@@ -43,22 +52,34 @@ class GrokClient:
             f"Ticker: {market_data.get('ticker')}\n"
             f"Subtitle: {market_data.get('subtitle')}\n"
             f"Category: {market_data.get('category')}\n"
-            f"Current Yes Price: {market_data.get('yes_ask', 'N/A')}\n\n"
+            f"Current Yes Price: {market_data.get('yes_ask', 'N/A')} cents\n"
+            f"Current No Price: {market_data.get('no_ask', 'N/A')} cents\n"
         )
+
+        if available_funds_cents is not None:
+            user_content += f"Available account funds: ${available_funds_cents / 100:.2f}\n"
+        if spending_limit_remaining_cents is not None:
+            user_content += (
+                "Remaining spending allowance: "
+                f"${spending_limit_remaining_cents / 100:.2f}\n"
+            )
+        user_content += "\n"
 
         if settlement_rules:
             user_content += f"{settlement_rules}\n\n"
 
         user_content += (
-            "If you recommend a trade, return the ticker and which side to buy "
-            "('yes' or 'no'), with a short explanation. "
-            "If you do NOT recommend a trade, return null for ticker and side, "
+            "If you recommend a trade, return the ticker, which side to buy "
+            "('yes' or 'no'), and a count. Based on your certainty and the funds shown, "
+            "choose as many contracts as you feel comfortable buying without exceeding "
+            "either available amount. Include a short explanation. "
+            "If you do NOT recommend a trade, return null for ticker, side, and count, "
             "but still include an explanation.\n\n"
-            "Example Yes Trade: {\"ticker\": \"KX-123\", \"side\": \"yes\", "
+            "Example Yes Trade: {\"ticker\": \"KX-123\", \"side\": \"yes\", \"count\": 8, "
             "\"explanation\": \"Undervalued relative to polling data.\"}\n"
-            "Example No Trade: {\"ticker\": \"KX-456\", \"side\": \"no\", "
+            "Example No Trade: {\"ticker\": \"KX-456\", \"side\": \"no\", \"count\": 3, "
             "\"explanation\": \"Market overestimates probability.\"}\n"
-            "Example Pass: {\"ticker\": null, \"side\": null, "
+            "Example Pass: {\"ticker\": null, \"side\": null, \"count\": null, "
             "\"explanation\": \"Not enough information.\"}"
         )
 
@@ -91,7 +112,7 @@ class GrokClient:
             return json.loads(content)
         except json.JSONDecodeError:
             logger.error(f"Failed to parse Grok response: {content}")
-            return {"ticker": None, "explanation": "JSON Error"}
+            return {"ticker": None, "side": None, "count": None, "explanation": "JSON Error"}
         except Exception as e:
             logger.error(f"Grok API failed: {e}")
-            return {"ticker": None, "explanation": str(e)}
+            return {"ticker": None, "side": None, "count": None, "explanation": str(e)}

--- a/new_position_bot/kalshi_client.py
+++ b/new_position_bot/kalshi_client.py
@@ -101,6 +101,11 @@ class KalshiClient:
         data = self._request("GET", "/portfolio/positions")
         return data.get("market_positions", [])
 
+    def get_balance(self) -> int:
+        """Returns the account balance available for trading, in cents."""
+        data = self._request("GET", "/portfolio/balance")
+        return data.get("balance", 0)
+
     def get_orders(
         self,
         start_time: Optional[datetime] = None,

--- a/new_position_bot/main.py
+++ b/new_position_bot/main.py
@@ -34,6 +34,26 @@ def get_kalshi_base_url(live: bool = False) -> str:
     return get_env_var("KALSHI_BASE_URL", DEMO_KALSHI_BASE_URL)
 
 
+def get_affordable_order_count(
+    requested_count: int,
+    order_price: int | None,
+    available_funds: int,
+    spending_limit_remaining: int,
+) -> int:
+    if (
+        not isinstance(order_price, int)
+        or isinstance(order_price, bool)
+        or order_price <= 0
+    ):
+        return 0
+
+    return min(
+        requested_count,
+        available_funds // order_price,
+        spending_limit_remaining // order_price,
+    )
+
+
 def _derive_series_ticker(event_ticker: str) -> str:
     """Best-effort extraction of series ticker from an event ticker.
 
@@ -254,11 +274,12 @@ def run_bot_logic(live: bool = False):
 
                 # Calculate order cost
                 order_price = market.get(f"{side}_ask")
-                affordable_count = min(
-                    available_funds // order_price,
-                    spending_limit_remaining // order_price,
+                order_count = get_affordable_order_count(
+                    requested_count=requested_count,
+                    order_price=order_price,
+                    available_funds=available_funds,
+                    spending_limit_remaining=spending_limit_remaining,
                 )
-                order_count = min(requested_count, affordable_count)
 
                 if order_count <= 0:
                     logger.warning(

--- a/new_position_bot/main.py
+++ b/new_position_bot/main.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 from typing import Dict
 
@@ -12,6 +13,25 @@ from utils import get_env_var, get_private_key
 # Configure basic logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+DEMO_KALSHI_BASE_URL = "https://demo-api.kalshi.co"
+PRODUCTION_KALSHI_BASE_URL = "https://api.elections.kalshi.com"
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(description="Run the Kalshi new-position trading bot.")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run against the Kalshi production API instead of the demo API.",
+    )
+    return parser.parse_args(args)
+
+
+def get_kalshi_base_url(live: bool = False) -> str:
+    if live:
+        return PRODUCTION_KALSHI_BASE_URL
+    return get_env_var("KALSHI_BASE_URL", DEMO_KALSHI_BASE_URL)
 
 
 def _derive_series_ticker(event_ticker: str) -> str:
@@ -110,11 +130,11 @@ def build_settlement_rules(
     return "\n".join(lines)
 
 
-def run_bot_logic():
+def run_bot_logic(live: bool = False):
     logger.info("Starting New Position Bot run...")
 
     # 1. Configuration
-    kalshi_base_url = get_env_var("KALSHI_BASE_URL", "https://demo-api.kalshi.co")
+    kalshi_base_url = get_kalshi_base_url(live)
     kalshi_api_key = get_env_var("KALSHI_API_KEY", required=True)
     lookback_hours = int(get_env_var("LOOKBACK_HOURS", "1"))
     grok_model = get_env_var("GROK_MODEL", "grok-4-1-fast-reasoning")
@@ -154,6 +174,9 @@ def run_bot_logic():
         except Exception as e:
             logger.warning(f"Failed to fetch orders for spending calculation: {e}")
             current_spending = 0  # Assume no spending if we can't fetch
+
+        available_funds = kalshi.get_balance()
+        logger.info("Available account funds: $%.2f", available_funds / 100)
 
         new_markets = kalshi.get_active_markets(created_after_hours=lookback_hours)
         viable_new_markets = [
@@ -196,13 +219,32 @@ def run_bot_logic():
             if settlement_rules:
                 logger.info("Injected settlement rules for %s", ticker)
 
-            recommendation = grok.analyze_market(market, settlement_rules=settlement_rules)
+            spending_limit_remaining = max(0, spending_limit_cents - current_spending)
+            recommendation = grok.analyze_market(
+                market,
+                settlement_rules=settlement_rules,
+                available_funds_cents=available_funds,
+                spending_limit_remaining_cents=spending_limit_remaining,
+            )
 
             rec_ticker = recommendation.get("ticker")
             explanation = recommendation.get("explanation")
             side = recommendation.get("side", "yes")
+            requested_count = recommendation.get("count")
 
             if rec_ticker and rec_ticker == ticker:
+                if (
+                    not isinstance(requested_count, int)
+                    or isinstance(requested_count, bool)
+                    or requested_count <= 0
+                ):
+                    logger.warning(
+                        "Skipping order for %s: Grok returned invalid count %r",
+                        ticker,
+                        requested_count,
+                    )
+                    continue
+
                 logger.info(
                     "Grok recommends BUY %s on %s. Reason: %s",
                     side.upper(),
@@ -212,7 +254,27 @@ def run_bot_logic():
 
                 # Calculate order cost
                 order_price = market.get(f"{side}_ask")
-                order_count = 1
+                affordable_count = min(
+                    available_funds // order_price,
+                    spending_limit_remaining // order_price,
+                )
+                order_count = min(requested_count, affordable_count)
+
+                if order_count <= 0:
+                    logger.warning(
+                        "Skipping order for %s: no funds remain within account and spending limits",
+                        ticker,
+                    )
+                    continue
+
+                if order_count < requested_count:
+                    logger.info(
+                        "Reduced requested count for %s from %s to affordable count %s",
+                        ticker,
+                        requested_count,
+                        order_count,
+                    )
+
                 order_cost = spending_tracker.calculate_order_cost(order_count, order_price)
 
                 # Check spending limit
@@ -242,10 +304,13 @@ def run_bot_logic():
 
                     # Update current spending after successful order
                     current_spending += order_cost
+                    available_funds -= order_cost
                     logger.info(
-                        "Order placed successfully: %s. Updated spending: $%.2f",
+                        "Order placed successfully: %s. Updated spending: $%.2f; "
+                        "available funds: $%.2f",
                         order_response,
                         current_spending / 100,
+                        available_funds / 100,
                     )
                 except Exception as trade_err:
                     logger.error(f"Failed to place order for {ticker}: {trade_err}")
@@ -271,4 +336,4 @@ def main(request):
 if __name__ == "__main__":
     # For local testing, ensure env vars are set or load from .env
     load_dotenv()
-    run_bot_logic()
+    run_bot_logic(live=parse_args().live)

--- a/new_position_bot/tests/test_grok_client.py
+++ b/new_position_bot/tests/test_grok_client.py
@@ -105,3 +105,37 @@ def test_analyze_market_no_rules_still_works():
         sent_payload = mock_post.call_args[1]["json"]
         user_message = sent_payload["messages"][1]["content"]
         assert "Settlement Rules" not in user_message
+
+
+def test_analyze_market_asks_for_quantity_with_available_funds():
+    client = GrokClient("api_key")
+    mock_response = {
+        "choices": [
+            {
+                "message": {
+                    "content": '{"ticker": "ABC", "side": "yes", "count": 8, '
+                    '"explanation": "High confidence"}'
+                }
+            }
+        ]
+    }
+
+    with patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = mock_response
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        client.analyze_market(
+            {"ticker": "ABC", "title": "Example", "yes_ask": 25, "no_ask": 75},
+            available_funds_cents=12500,
+            spending_limit_remaining_cents=4000,
+        )
+
+        sent_payload = mock_post.call_args[1]["json"]
+        system_message = sent_payload["messages"][0]["content"]
+        user_message = sent_payload["messages"][1]["content"]
+
+        assert "'count' (positive integer or null)" in system_message
+        assert "Available account funds: $125.00" in user_message
+        assert "Remaining spending allowance: $40.00" in user_message
+        assert "as many contracts as you feel comfortable buying" in user_message

--- a/new_position_bot/tests/test_kalshi_client.py
+++ b/new_position_bot/tests/test_kalshi_client.py
@@ -172,6 +172,16 @@ def test_get_orders_returns_all_orders_when_no_identifier(mock_kalshi):
         assert len(orders) == 2
 
 
+def test_get_balance_returns_available_funds(mock_kalshi):
+    with patch.object(mock_kalshi, "_request") as mock_req:
+        mock_req.return_value = {"balance": 12500, "portfolio_value": 18000}
+
+        balance = mock_kalshi.get_balance()
+
+        mock_req.assert_called_once_with("GET", "/portfolio/balance")
+        assert balance == 12500
+
+
 def test_get_market_returns_market_detail(mock_kalshi):
     with patch.object(mock_kalshi, "_request") as mock_req:
         mock_req.return_value = {

--- a/new_position_bot/tests/test_main.py
+++ b/new_position_bot/tests/test_main.py
@@ -1,6 +1,6 @@
 from unittest.mock import ANY, MagicMock, patch
 
-from main import get_kalshi_base_url, parse_args
+from main import get_affordable_order_count, get_kalshi_base_url, parse_args
 
 
 def test_live_flag_selects_production_mode():
@@ -13,6 +13,18 @@ def test_live_mode_selects_production_api(monkeypatch):
 
     assert get_kalshi_base_url(live=False) == "https://demo-api.kalshi.co"
     assert get_kalshi_base_url(live=True) == "https://api.elections.kalshi.com"
+
+
+def test_zero_price_has_no_affordable_contracts():
+    assert (
+        get_affordable_order_count(
+            requested_count=10,
+            order_price=0,
+            available_funds=1000,
+            spending_limit_remaining=1000,
+        )
+        == 0
+    )
 
 
 def test_bot_uses_grok_contract_count_and_available_funds(monkeypatch):

--- a/new_position_bot/tests/test_main.py
+++ b/new_position_bot/tests/test_main.py
@@ -1,0 +1,109 @@
+from unittest.mock import ANY, MagicMock, patch
+
+from main import get_kalshi_base_url, parse_args
+
+
+def test_live_flag_selects_production_mode():
+    assert parse_args([]).live is False
+    assert parse_args(["--live"]).live is True
+
+
+def test_live_mode_selects_production_api(monkeypatch):
+    monkeypatch.delenv("KALSHI_BASE_URL", raising=False)
+
+    assert get_kalshi_base_url(live=False) == "https://demo-api.kalshi.co"
+    assert get_kalshi_base_url(live=True) == "https://api.elections.kalshi.com"
+
+
+def test_bot_uses_grok_contract_count_and_available_funds(monkeypatch):
+    monkeypatch.setenv("KALSHI_API_KEY", "kalshi-key")
+    monkeypatch.setenv("XAI_API_KEY", "xai-key")
+    monkeypatch.setenv("SPENDING_LIMIT_CENTS", "4000")
+
+    market = {
+        "ticker": "ABC",
+        "title": "Example",
+        "yes_ask": 25,
+        "no_ask": 75,
+    }
+    kalshi = MagicMock()
+    kalshi.get_orders.return_value = []
+    kalshi.get_balance.return_value = 12500
+    kalshi.get_active_markets.return_value = [market]
+    kalshi.get_positions.return_value = []
+    kalshi.get_market.return_value = {}
+
+    grok = MagicMock()
+    grok.analyze_market.return_value = {
+        "ticker": "ABC",
+        "side": "yes",
+        "count": 8,
+        "explanation": "High confidence",
+    }
+
+    with (
+        patch("main.get_private_key", return_value="private-key"),
+        patch("main.KalshiClient", return_value=kalshi),
+        patch("main.GrokClient", return_value=grok),
+    ):
+        from main import run_bot_logic
+
+        assert run_bot_logic() == ("Run Complete", 200)
+
+    grok.analyze_market.assert_called_once_with(
+        market,
+        settlement_rules=ANY,
+        available_funds_cents=12500,
+        spending_limit_remaining_cents=4000,
+    )
+    kalshi.create_market_order.assert_called_once_with(
+        "ABC",
+        side="yes",
+        count=8,
+        price=25,
+        bot_identifier="NEW_POSITION_BOT",
+    )
+
+
+def test_bot_caps_contract_count_to_affordable_funds(monkeypatch):
+    monkeypatch.setenv("KALSHI_API_KEY", "kalshi-key")
+    monkeypatch.setenv("XAI_API_KEY", "xai-key")
+    monkeypatch.setenv("SPENDING_LIMIT_CENTS", "4000")
+
+    market = {
+        "ticker": "ABC",
+        "title": "Example",
+        "yes_ask": 25,
+        "no_ask": 75,
+    }
+    kalshi = MagicMock()
+    kalshi.get_orders.return_value = []
+    kalshi.get_balance.return_value = 1000
+    kalshi.get_active_markets.return_value = [market]
+    kalshi.get_positions.return_value = []
+    kalshi.get_market.return_value = {}
+
+    grok = MagicMock()
+    grok.analyze_market.return_value = {
+        "ticker": "ABC",
+        "side": "yes",
+        "count": 500,
+        "explanation": "High confidence",
+    }
+
+    with (
+        patch("main.get_private_key", return_value="private-key"),
+        patch("main.KalshiClient", return_value=kalshi),
+        patch("main.GrokClient", return_value=grok),
+    ):
+        from main import run_bot_logic
+
+        assert run_bot_logic() == ("Run Complete", 200)
+
+    kalshi.create_market_order.assert_called_once_with(
+        "ABC",
+        side="yes",
+        count=40,
+        price=25,
+        bot_identifier="NEW_POSITION_BOT",
+    )


### PR DESCRIPTION

## Summary

- Allow Grok to recommend a contract count based on its confidence, available account funds, and the remaining spending allowance.
- Validate and cap the recommended count so orders stay within the available balance and configured spending limit.
- Add a `--live` flag for selecting the Kalshi production API while keeping demo mode as the default.
- Add protection against zero or invalid contract prices.
- Document the new command-line option.

## Testing

- `python -m ruff check .`
- `python -m pytest`
- 40 tests passed

Closes #2
Closes #4